### PR TITLE
Fix BitSeq Snoc instance

### DIFF
--- a/src/HaskellWorks/Data/RankSelect/Internal/BitSeq.hs
+++ b/src/HaskellWorks/Data/RankSelect/Internal/BitSeq.hs
@@ -85,8 +85,8 @@ instance HW.Cons BitSeq where
 instance HW.Snoc BitSeq where
   snoc (BitSeq ft) b = BitSeq $ case FT.viewr ft of
     lt :> Elem w nw -> if nw >= 0 && nw < 64
-      then Elem (w .|. (bw .<. nw)) (nw + 1) <| lt
-      else Elem bw 1                         <| lt
+      then lt |> Elem (w .|. (bw .<. nw)) (nw + 1)
+      else ft |> Elem bw 1
     FT.EmptyR        -> FT.singleton (Elem bw 1)
     where bw = if b then 1 else 0
 

--- a/src/HaskellWorks/Data/RankSelect/Internal/BitSeq.hs
+++ b/src/HaskellWorks/Data/RankSelect/Internal/BitSeq.hs
@@ -99,6 +99,9 @@ instance Semigroup BitSeq where
       FT.EmptyL -> tr
     FT.EmptyR -> FT.empty
 
+instance Monoid BitSeq where
+  mempty = BitSeq mempty
+
 instance Select1 BitSeq where
   select1 (BitSeq ft) n = case FT.split (atPopCountBelow n) ft of
     (lt, _) -> case FT.viewr lt of


### PR DESCRIPTION
This is covered by tests but it appears they are not functioning correctly- only single item lists are generated in `test/HaskellWorks/Data/RankSelect/BitSeqSpec.hs`. E.g. try printing `bs` under snoc test: 

```
  it "(|>) should snoc" $ requireTest $ do
    b         <- forAll $ G.bool
    bs        <- forAll $ G.list (R.linear 1 1000) G.bool
    ps        <- forAll $ pure $ BS.fromBools bs

    liftIO $ print bs -- Only ever a single element
```

Using `resize` results in lists greater than 1 element and causes the test to fail (without this PR) 

```
  it "(|>) should snoc" $ requireTest $ do
    b         <- forAll $ G.bool
    bs        <- forAll $ G.resize 100 $ G.list (R.linear 1 1000) G.bool
    ps        <- forAll $ pure $ BS.fromBools bs

    liftIO $ print bs -- Now many elements
```

I'm not sure on the correct fix for the tests as I am less familiar with hedgehog, but there seems to be some non obvious interaction with hedgehog 'Size'.